### PR TITLE
Fix all 7 critical bugs in persistance.ts and TournamentStrongman

### DIFF
--- a/src/components/TournamentStrongman.tsx
+++ b/src/components/TournamentStrongman.tsx
@@ -68,14 +68,14 @@ const TournamentStrongman: React.FC<TournamentStrongmanProps> = ({ initialTourna
   };
 
   const updateParticipants = (newParticipants: string) => {
-    const participants = newParticipants.split(',');
-    const currentTournament = { ...tournament };
-    participants.forEach((participant) => {
-      if (participant.trim()) {
-        currentTournament.participants.push(participant);
-      }
-    });
+    const added = newParticipants
+      .split(',')
+      .filter((p) => p.trim())
+      .map((p) => p.trim());
+    const updatedParticipants = [...tournament.participants, ...added];
+    const currentTournament = { ...tournament, participants: updatedParticipants };
     updateTournament(currentTournament);
+    setSortedParticipants(updatedParticipants);
     handleCloseParticipantsModal();
   };
 
@@ -88,11 +88,12 @@ const TournamentStrongman: React.FC<TournamentStrongmanProps> = ({ initialTourna
 
   const setEventResult = (result: string, participant: string, event: string): void => {
     const performance = result.replace(/[^0-9.]/g, '');
-    let currentTournament = { ...tournament };
-    currentTournament.eventResults = currentTournament.eventResults || {};
-    currentTournament.eventResults[event] = currentTournament.eventResults[event] || {};
-    currentTournament.eventResults[event][participant] = currentTournament.eventResults[event][participant] || {};
-    currentTournament.eventResults[event][participant].performance = parseFloat(performance);
+    const parsedPerformance = parseFloat(performance);
+    const eventResults = JSON.parse(JSON.stringify(tournament.eventResults || {}));
+    eventResults[event] = eventResults[event] || {};
+    eventResults[event][participant] = eventResults[event][participant] || {};
+    eventResults[event][participant].performance = isNaN(parsedPerformance) ? 0 : parsedPerformance;
+    let currentTournament: Tournament = { ...tournament, eventResults };
     currentTournament = calculatePoints(currentTournament);
     updateTournament(currentTournament);
   };
@@ -112,13 +113,15 @@ const TournamentStrongman: React.FC<TournamentStrongmanProps> = ({ initialTourna
 
   const sortByPoints = (property: string, isAsc: boolean) => (a: string, b: string) => {
     if (property === 'overall') {
+      if (!tournament.overall || !tournament.overall[a] || !tournament.overall[b]) return 0;
       return isAsc
-        ? tournament.overall![a].points - tournament.overall![b].points
-        : tournament.overall![b].points - tournament.overall![a].points;
+        ? tournament.overall[a].points - tournament.overall[b].points
+        : tournament.overall[b].points - tournament.overall[a].points;
     } else {
-      return isAsc
-        ? tournament.eventResults![property][a].points - tournament.eventResults![property][b].points
-        : tournament.eventResults![property][b].points - tournament.eventResults![property][a].points;
+      if (!tournament.eventResults || !tournament.eventResults[property]) return 0;
+      const eventResult = tournament.eventResults[property];
+      if (!eventResult[a] || !eventResult[b]) return 0;
+      return isAsc ? eventResult[a].points - eventResult[b].points : eventResult[b].points - eventResult[a].points;
     }
   };
 
@@ -127,7 +130,7 @@ const TournamentStrongman: React.FC<TournamentStrongmanProps> = ({ initialTourna
     setOrder(isAsc ? 'desc' : 'asc');
     setOrderBy(property);
 
-    const ordered = tournament.participants.sort(sortByPoints(property, isAsc));
+    const ordered = [...tournament.participants].sort(sortByPoints(property, isAsc));
     setSortedParticipants(ordered);
   };
 

--- a/src/logic/persistance.ts
+++ b/src/logic/persistance.ts
@@ -1,23 +1,26 @@
 import { Tournament } from '../types';
 
 export const getExistingTournaments = () => {
-    const tournamentsString = localStorage.getItem('existingTournaments');
-    if (tournamentsString) {
-        return JSON.parse(tournamentsString) as Tournament[];
-    } else {
-        return undefined;
-    }
-}
+  const tournamentsString = localStorage.getItem('existingTournaments');
+  if (tournamentsString) {
+    return JSON.parse(tournamentsString) as Tournament[];
+  } else {
+    return undefined;
+  }
+};
 
 export const getTournament = (name: string) => {
-    const existingTournaments = getExistingTournaments();
-    if (existingTournaments) {
-        existingTournaments.find((tournament) => {tournament.name === name});
-    }
-}
+  const existingTournaments = getExistingTournaments();
+  if (existingTournaments) {
+    return existingTournaments.find((tournament) => tournament.name === name);
+  }
+};
 
 export const saveTournament = (tournament: Tournament) => {
-    const existingTournaments = getExistingTournaments() ?? [];
-    const updatedTournaments = existingTournaments.map(item => item.name === tournament.name ? tournament : item);
-    localStorage.setItem('existingTournaments', JSON.stringify(updatedTournaments));
-}
+  const existingTournaments = getExistingTournaments() ?? [];
+  const exists = existingTournaments.some((item) => item.name === tournament.name);
+  const updatedTournaments = exists
+    ? existingTournaments.map((item) => (item.name === tournament.name ? tournament : item))
+    : [...existingTournaments, tournament];
+  localStorage.setItem('existingTournaments', JSON.stringify(updatedTournaments));
+};


### PR DESCRIPTION
- getTournament: fix block-body arrow fn (never returned) + add return statement
- saveTournament: replace map-only with upsert so new tournaments are persisted
- updateParticipants: spread instead of push to avoid mutating state array; sync sortedParticipants after every participant change (issues 3 & 4)
- setEventResult: JSON deep-copy eventResults before mutation; validate NaN from parseFloat so empty fields store 0 instead of NaN (issues 5 & 10 partial)
- sortByPoints: guard against undefined overall/eventResults before accessing nested properties — prevents crash before any scores are entered (issue 6)
- sortTable: copy participants array before sort to avoid mutating React state (issue 7)